### PR TITLE
Fix formatting in Makefile for snd_hda_codec_realtek

### DIFF
--- a/snd_hda_codec_realtek/Makefile
+++ b/snd_hda_codec_realtek/Makefile
@@ -1,6 +1,7 @@
-snd-hda-codec-realtek-objs :=	patch_realtek.o
+snd-hda-codec-realtek-objs := patch_realtek.o
 obj-m += snd-hda-codec-realtek.o
-EXTRA_CFLAGS=-I$(PWD)/inc
+
+ccflags-y := -I$(PWD)/inc
 
 all:
 	make -C /lib/modules/${kernelver}/build M=$(PWD) modules


### PR DESCRIPTION
This fixes the issue where it wont install using dkms, because it complains it cant find the .h files.